### PR TITLE
Hold trait notification when setting multiple attributes from js

### DIFF
--- a/ipython_widgets/widgets/widget.py
+++ b/ipython_widgets/widgets/widget.py
@@ -282,13 +282,15 @@ class Widget(LoggingConfigurable):
 
     def set_state(self, sync_data):
         """Called when a state is received from the front-end."""
-        for name in self.keys:
-            if name in sync_data:
-                json_value = sync_data[name]
-                from_json = self.trait_metadata(name, 'from_json', self._trait_from_json)
-                with self._lock_property(name, json_value):
-                    setattr(self, name, from_json(json_value))
-    
+        with self.hold_trait_notifications():
+            for name in self.keys:
+                if name in sync_data:
+                    json_value = sync_data[name]
+                    from_json = self.trait_metadata(name, 'from_json',
+                                                    self._trait_from_json)
+                    with self._lock_property(name, json_value):
+                        setattr(self, name, from_json(json_value))
+
     def send(self, content, buffers=None):
         """Sends a custom msg to the widget model in the front-end.
 

--- a/ipython_widgets/widgets/widget.py
+++ b/ipython_widgets/widgets/widget.py
@@ -286,11 +286,11 @@ class Widget(LoggingConfigurable):
         # be locked when the hold_trait_notification context manager is
         # released and notifications are fired.
         with self._lock_property(**sync_data), self.hold_trait_notifications():
-            for name, value in sync_data.iteritems():
+            for name in sync_data:
                 if name in self.keys:
                     from_json = self.trait_metadata(name, 'from_json',
                                                     self._trait_from_json)
-                    setattr(self, name, from_json(value))
+                    setattr(self, name, from_json(sync_data[name]))
 
     def send(self, content, buffers=None):
         """Sends a custom msg to the widget model in the front-end.


### PR DESCRIPTION
This is holding notifications when setting multiple trait attributes from the front-end

Currently, when doing something like the following in a widget view:

```JavaScript
this.model.set('x', x);
this.model.set('y', y);
this.touch();
```
trait assignments and notifications are made and sent in the (arbitrary) order in which the attributes are set from the bulk updates in the backend. If the first set is `'x'` and the change handler for `x` uses `'y'`, it would use the old value...

This should solve this issue using the new `hold_trait_notifications` context manager. 