### PR TITLE
Fix bugs in the accordion and tab widget styling example notebook.

### DIFF
--- a/examples/Widget Styling.ipynb
+++ b/examples/Widget Styling.ipynb
@@ -209,7 +209,7 @@
     "zip2 = widgets.BoundedIntText(description='Zip:', min=0, max=99999)\n",
     "page2 = widgets.Box(children=[name2, zip2])\n",
     "\n",
-    "accord = widgets.Accordion(children=[page1, page2])\n",
+    "accord = widgets.Accordion(children=[page1, page2], width=400)\n",
     "display(accord)\n",
     "\n",
     "accord.set_title(0, 'From')\n",
@@ -235,13 +235,13 @@
    },
    "outputs": [],
    "source": [
-    "name = widgets.Text(description='Name:')\n",
-    "color = widgets.Dropdown(description='Color:', options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'])\n",
-    "page1 = widgets.Box(children=[name, color])\n",
+    "name = widgets.Text(description='Name:', padding=4)\n",
+    "color = widgets.Dropdown(description='Color:', padding=4, options=['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'])\n",
+    "page1 = widgets.Box(children=[name, color], padding=4)\n",
     "\n",
-    "age = widgets.IntSlider(description='Age:', min=0, max=120, value=50)\n",
-    "gender = widgets.RadioButtons(description='Gender:', options=['male', 'female'])\n",
-    "page2 = widgets.Box(children=[age, gender])\n",
+    "age = widgets.IntSlider(description='Age:', padding=4, min=0, max=120, value=50)\n",
+    "gender = widgets.RadioButtons(description='Gender:', padding=4, options=['male', 'female'])\n",
+    "page2 = widgets.Box(children=[age, gender], padding=4)\n",
     "\n",
     "tabs = widgets.Tab(children=[page1, page2])\n",
     "display(tabs)\n",
@@ -577,7 +577,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.2"
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
closes #10 

Padding was missing from all of the contents in the tab widget.
The accordion widget needed a fixed width so it wouldn't change size when collapsed.